### PR TITLE
Fix implicit definition of timing routines in CortexSuite

### DIFF
--- a/CortexSuite/cortex/lda/lda-estimate.c
+++ b/CortexSuite/cortex/lda/lda-estimate.c
@@ -18,6 +18,7 @@
 // USA
 
 #include "lda-estimate.h"
+#include "photonTiming.h"
 
 /*
  * perform inference on a document and update sufficient statistics

--- a/CortexSuite/cortex/liblinear/tron.c
+++ b/CortexSuite/cortex/liblinear/tron.c
@@ -5,6 +5,7 @@
 #include <stdarg.h>
 #include "tron.h"
 #include "linear.h"
+#include "photonTiming.h"
 
 #ifndef mindouble
 static double mindouble(double x,double y) { return (x<y)?x:y; }

--- a/CortexSuite/cortex/motion-estimation/App.c
+++ b/CortexSuite/cortex/motion-estimation/App.c
@@ -1,6 +1,7 @@
 //#include <BmpHandler.h>
 #include "MotionEstimation.h"
 #include "BmpHandler.h"
+#include "photonTiming.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/CortexSuite/cortex/pca/pca.c
+++ b/CortexSuite/cortex/pca/pca.c
@@ -23,6 +23,7 @@
 #include <string.h>
 #include <math.h>
 #include <stdlib.h>
+#include "photonTiming.h"
 
 #define SIGN(a, b) ( (b) < 0 ? -fabs(a) : fabs(a) )
 

--- a/CortexSuite/cortex/sphinx/main.c
+++ b/CortexSuite/cortex/sphinx/main.c
@@ -1,6 +1,7 @@
 #define MAX_LENGTH 1024
 
 #include "helper/pocketsphinx.h"
+#include "../../includes/photonTiming.h"
 
 int
 main(int argc, char *argv[])

--- a/CortexSuite/cortex/srr/App.c
+++ b/CortexSuite/cortex/srr/App.c
@@ -2,6 +2,7 @@
 #include "BmpHandler.h"
 #include "SystemMatrices.h"
 #include "SRREngine.h"
+#include "photonTiming.h"
 #include <string.h>
 
 

--- a/CortexSuite/includes/photonTiming.h
+++ b/CortexSuite/includes/photonTiming.h
@@ -1,0 +1,11 @@
+#ifndef _PHOTON_TIMING_H
+#define _PHOTON_TIMING_H
+
+// Timing routines
+
+extern unsigned int * photonStartTiming();
+extern unsigned int * photonReportTiming(unsigned int* startCycles,unsigned int* endCycles);
+extern void photonPrintTiming(unsigned int * elapsed);
+extern unsigned int * photonEndTiming();
+
+#endif // _PHOTON_TIMING_H


### PR DESCRIPTION
The timing routines were used without being declared leading to lots of build warnings. Add a new header photonTiming.h that declares the timing routines and include it in the required places.