### PR TITLE
Fix multiple definition of global variables in the CortexSuite lda benchmark

### DIFF
--- a/CortexSuite/cortex/lda/lda-inference.c
+++ b/CortexSuite/cortex/lda/lda-inference.c
@@ -19,6 +19,9 @@
 
 #include "lda-inference.h"
 
+float VAR_CONVERGED;
+int VAR_MAX_ITER;
+
 /*
  * variational inference
  *

--- a/CortexSuite/cortex/lda/lda-inference.h
+++ b/CortexSuite/cortex/lda/lda-inference.h
@@ -7,8 +7,8 @@
 #include "lda.h"
 #include "utils.h"
 
-float VAR_CONVERGED;
-int VAR_MAX_ITER;
+extern float VAR_CONVERGED;
+extern int VAR_MAX_ITER;
 
 double lda_inference(document*, lda_model*, double*, double**);
 double compute_likelihood(document*, lda_model*, double**, double*);


### PR DESCRIPTION
Global variables should not be defined in header files as this leads to multiple definitions which prevents linking. Move the globals from lda-inference.h into lda-inference.c and provide forward declartions in the header.